### PR TITLE
Add manual model fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ print(result.final_output)
 
 (_For Jupyter notebook users, see [hello_world_jupyter.ipynb](examples/basic/hello_world_jupyter.ipynb)_)
 
+> [!TIP]
+> Want to exercise the agent loop without an API key? Pass `RunConfig(model=ManualModel())` when calling `Runner.run` or `Runner.run_sync`. The runner prints the current context (system prompt, conversation history, tools, and handoffs) and waits for you to type the next assistant response.
+
 ## Handoffs example
 
 ```python

--- a/docs/ja/running_agents.md
+++ b/docs/ja/running_agents.md
@@ -50,7 +50,7 @@ Runner は次のループを実行します。
 
 `run_config` パラメーターで、エージェント実行のグローバル設定を構成できます。
 
--   [`model`][agents.run.RunConfig.model]: 各 Agent の `model` 設定に関わらず、使用するグローバルな LLM モデルを設定します。
+-   [`model`][agents.run.RunConfig.model]: 各 Agent の `model` 設定に関わらず、使用するグローバルな LLM モデルを設定します。API を呼び出さずに手動で応答を入力したい場合は、`agents` から `ManualModel()` を渡すとコンテキストが表示され、次の応答を入力するまで待機します（例: `RunConfig(model=ManualModel())`）。
 -   [`model_provider`][agents.run.RunConfig.model_provider]: モデル名を解決するモデルプロバイダーで、既定は OpenAI です。
 -   [`model_settings`][agents.run.RunConfig.model_settings]: エージェント固有の設定を上書きします。例: グローバルな `temperature` や `top_p` を設定できます。
 -   [`input_guardrails`][agents.run.RunConfig.input_guardrails], [`output_guardrails`][agents.run.RunConfig.output_guardrails]: すべての実行に含める入力/出力 ガードレール のリストです。

--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -46,7 +46,7 @@ Streaming allows you to additionally receive streaming events as the LLM runs. O
 
 The `run_config` parameter lets you configure some global settings for the agent run:
 
--   [`model`][agents.run.RunConfig.model]: Allows setting a global LLM model to use, irrespective of what `model` each Agent has.
+-   [`model`][agents.run.RunConfig.model]: Allows setting a global LLM model to use, irrespective of what `model` each Agent has. For local debugging you can also pass `ManualModel()` (from `agents`) so the runner prints the context and waits for you to type the assistant's reply, e.g. `RunConfig(model=ManualModel())`.
 -   [`model_provider`][agents.run.RunConfig.model_provider]: A model provider for looking up model names, which defaults to OpenAI.
 -   [`model_settings`][agents.run.RunConfig.model_settings]: Overrides agent-specific settings. For example, you can set a global `temperature` or `top_p`.
 -   [`input_guardrails`][agents.run.RunConfig.input_guardrails], [`output_guardrails`][agents.run.RunConfig.output_guardrails]: A list of input or output guardrails to include on all runs.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -49,6 +49,7 @@ from .lifecycle import AgentHooks, RunHooks
 from .memory import OpenAIConversationsSession, Session, SessionABC, SQLiteSession
 from .model_settings import ModelSettings
 from .models.interface import Model, ModelProvider, ModelTracing
+from .models.manual import ManualModel, manual_prompt_interaction
 from .models.multi_provider import MultiProvider
 from .models.openai_chatcompletions import OpenAIChatCompletionsModel
 from .models.openai_provider import OpenAIProvider
@@ -175,6 +176,8 @@ __all__ = [
     "Runner",
     "run_demo_loop",
     "Model",
+    "ManualModel",
+    "manual_prompt_interaction",
     "ModelProvider",
     "ModelTracing",
     "ModelSettings",

--- a/src/agents/models/manual.py
+++ b/src/agents/models/manual.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from pprint import pformat
+from typing import Any
+
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseUsage,
+)
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from ..agent_output import AgentOutputSchemaBase
+from ..handoffs import Handoff
+from ..items import ItemHelpers, ModelResponse, TResponseInputItem, TResponseStreamEvent
+from ..model_settings import ModelSettings
+from ..tool import Tool
+from ..usage import Usage
+from .interface import Model, ModelTracing
+
+ManualResponseProvider = Callable[[], Awaitable[str]]
+ManualPrintFn = Callable[[str], Any]
+
+
+_RESPONSE_ID = "manual-response"
+_MESSAGE_ID = "manual-message"
+
+
+def _tool_name(tool: Tool) -> str:
+    return getattr(tool, "name", tool.__class__.__name__)
+
+
+def _tool_description(tool: Tool) -> str | None:
+    return getattr(tool, "description", None) or getattr(tool, "tool_description", None)
+
+
+def _format_tools(tools: Sequence[Tool]) -> list[str]:
+    formatted: list[str] = []
+    for tool in tools:
+        name = _tool_name(tool)
+        description = _tool_description(tool)
+        if description:
+            formatted.append(f"  - {name}: {description}")
+        else:
+            formatted.append(f"  - {name}")
+    return formatted
+
+
+def _format_handoffs(handoffs: Sequence[Handoff]) -> list[str]:
+    formatted: list[str] = []
+    for handoff in handoffs:
+        description = handoff.tool_description
+        if description:
+            formatted.append(f"  - {handoff.agent_name} via `{handoff.tool_name}`: {description}")
+        else:
+            formatted.append(f"  - {handoff.agent_name} via `{handoff.tool_name}`")
+    return formatted
+
+
+def _default_response_provider() -> Awaitable[str]:
+    return asyncio.to_thread(input, "Manual response: ")
+
+
+async def manual_prompt_interaction(
+    *,
+    system_instructions: str | None,
+    input: str | list[TResponseInputItem],
+    tools: Sequence[Tool],
+    handoffs: Sequence[Handoff],
+    prompt: ResponsePromptParam | None,
+    print_fn: ManualPrintFn = print,
+    response_provider: ManualResponseProvider | None = None,
+) -> str:
+    """Prompt for a manual response by printing context to stdout."""
+
+    normalized_input = ItemHelpers.input_to_new_input_list(input)
+
+    print_fn("=== Manual model interaction ===")
+    if system_instructions:
+        print_fn("System instructions:")
+        print_fn(system_instructions)
+    else:
+        print_fn("System instructions: <none>")
+
+    print_fn("Conversation items:")
+    print_fn(pformat(normalized_input, sort_dicts=False))
+
+    if prompt is not None:
+        print_fn("Prompt configuration:")
+        print_fn(pformat(prompt, sort_dicts=False))
+
+    if tools:
+        print_fn("Available tools:")
+        for line in _format_tools(tools):
+            print_fn(line)
+    else:
+        print_fn("Available tools: none")
+
+    if handoffs:
+        print_fn("Available handoffs:")
+        for line in _format_handoffs(handoffs):
+            print_fn(line)
+    else:
+        print_fn("Available handoffs: none")
+
+    print_fn("Provide the next assistant message.")
+
+    provider = response_provider or _default_response_provider
+    return await provider()
+
+
+def _build_output_message(text: str) -> ResponseOutputMessage:
+    return ResponseOutputMessage(
+        id=_MESSAGE_ID,
+        content=[
+            ResponseOutputText(text=text, type="output_text", annotations=[]),
+        ],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+
+def _usage_to_response_usage(usage: Usage) -> ResponseUsage:
+    return ResponseUsage(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        total_tokens=usage.total_tokens,
+        input_tokens_details=InputTokensDetails(
+            cached_tokens=usage.input_tokens_details.cached_tokens
+        ),
+        output_tokens_details=OutputTokensDetails(
+            reasoning_tokens=usage.output_tokens_details.reasoning_tokens
+        ),
+    )
+
+
+def _build_completed_event(message: ResponseOutputMessage, usage: Usage) -> ResponseCompletedEvent:
+    response = Response(
+        id=_RESPONSE_ID,
+        created_at=0,
+        model="manual",
+        object="response",
+        output=[message],
+        tool_choice="none",
+        tools=[],
+        top_p=None,
+        usage=_usage_to_response_usage(usage),
+        parallel_tool_calls=False,
+    )
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=response,
+        sequence_number=0,
+    )
+
+
+class ManualModel(Model):
+    """A simple model implementation that prompts a human for responses."""
+
+    def __init__(
+        self,
+        *,
+        print_fn: ManualPrintFn = print,
+        response_provider: ManualResponseProvider | None = None,
+    ) -> None:
+        self._print_fn = print_fn
+        self._response_provider = response_provider
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> ModelResponse:
+        del model_settings, output_schema, tracing, previous_response_id, conversation_id
+
+        response_text = await manual_prompt_interaction(
+            system_instructions=system_instructions,
+            input=input,
+            tools=tools,
+            handoffs=handoffs,
+            prompt=prompt,
+            print_fn=self._print_fn,
+            response_provider=self._response_provider,
+        )
+
+        message = _build_output_message(response_text)
+        usage = Usage()
+        return ModelResponse(output=[message], usage=usage, response_id=_RESPONSE_ID)
+
+    async def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        del model_settings, output_schema, tracing, previous_response_id, conversation_id
+
+        response_text = await manual_prompt_interaction(
+            system_instructions=system_instructions,
+            input=input,
+            tools=tools,
+            handoffs=handoffs,
+            prompt=prompt,
+            print_fn=self._print_fn,
+            response_provider=self._response_provider,
+        )
+
+        message = _build_output_message(response_text)
+        usage = Usage()
+        yield _build_completed_event(message, usage)

--- a/tests/agents/models/test_manual_model.py
+++ b/tests/agents/models/test_manual_model.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from openai.types.responses import ResponseCompletedEvent, ResponseOutputMessage, ResponseOutputText
+
+from agents import ManualModel, ModelSettings, ModelTracing
+from agents.handoffs import Handoff
+from agents.tool import FunctionTool
+
+
+@pytest.mark.asyncio
+async def test_get_response_manual_model() -> None:
+    printed: list[str] = []
+    responses = ["Manual reply"]
+
+    async def response_provider() -> str:
+        return responses.pop(0)
+
+    async def noop_tool(context: Any, arguments: str) -> str:
+        return "ok"
+
+    async def noop_handoff(context: Any, arguments: str):
+        raise AssertionError("handoff should not run in test")
+
+    tool = FunctionTool(
+        name="test_tool",
+        description="A simple helper.",
+        params_json_schema={},
+        on_invoke_tool=noop_tool,
+    )
+    handoff = Handoff(
+        tool_name="transfer_to_helper",
+        tool_description="Transfer to helper agent.",
+        input_json_schema={},
+        on_invoke_handoff=noop_handoff,
+        agent_name="Helper",
+    )
+
+    model = ManualModel(print_fn=printed.append, response_provider=response_provider)
+
+    response = await model.get_response(
+        system_instructions="Be concise.",
+        input="Hello",
+        model_settings=ModelSettings(),
+        tools=[tool],
+        output_schema=None,
+        handoffs=[handoff],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert len(response.output) == 1
+    message = response.output[0]
+    assert isinstance(message, ResponseOutputMessage)
+    assert len(message.content) == 1
+    first_content = message.content[0]
+    assert isinstance(first_content, ResponseOutputText)
+    assert first_content.text == "Manual reply"
+    assert response.response_id == "manual-response"
+    assert response.usage.requests == 0
+    assert response.usage.total_tokens == 0
+
+    assert printed[0] == "=== Manual model interaction ==="
+    assert any("Hello" in line for line in printed)
+    assert any("test_tool" in line for line in printed)
+    assert any("Helper" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_stream_response_manual_model() -> None:
+    printed: list[str] = []
+    responses = ["Streamed manual response"]
+
+    async def response_provider() -> str:
+        return responses.pop(0)
+
+    model = ManualModel(print_fn=printed.append, response_provider=response_provider)
+
+    events = [
+        event
+        async for event in model.stream_response(
+            system_instructions=None,
+            input=[{"role": "user", "content": "Ping"}],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+    ]
+
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, ResponseCompletedEvent)
+    assert event.response.id == "manual-response"
+    assert event.response.usage is not None
+    assert event.response.usage.input_tokens == 0
+    assert event.response.usage.output_tokens == 0
+    assert len(event.response.output) == 1
+    streamed_message = event.response.output[0]
+    assert isinstance(streamed_message, ResponseOutputMessage)
+    assert streamed_message.content
+    first_content = streamed_message.content[0]
+    assert isinstance(first_content, ResponseOutputText)
+    assert first_content.text == "Streamed manual response"
+
+    assert printed[0] == "=== Manual model interaction ==="
+    assert any("Ping" in line for line in printed)
+    assert any("Available tools: none" == line for line in printed)
+    assert any("Available handoffs: none" == line for line in printed)


### PR DESCRIPTION
## Summary
- add a ManualModel implementation that prompts for responses via a shared helper and yields streaming events
- export the manual fallback from the agents package and document how to use it in the README and run-config docs
- cover the ManualModel sync and streaming flows with deterministic unit tests

## Testing
- make format
- make lint
- make mypy *(fails: missing optional dependencies such as numpy, litellm, sqlalchemy in the sandbox environment)*
- make tests *(fails: missing optional dependencies such as numpy and litellm in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4c66922083289e93e0fff832cfe9